### PR TITLE
[v0.2.0] Explicit Schema Definition

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Ample, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -16,7 +16,42 @@ const processMarkdown = require("./utils/process-markdown")
 // TODO: Fix tests
 // TODO: Update documentation
 
-exports.onCreateNode = ({ node, actions, createNodeId, getNode, createContentDigest }, options) => {
+exports.createSchemaCustomization = ({ actions }) => {
+  const { createTypes } = actions
+
+  const models = ["Page", "Redirect", "AdminReferences", "AdminSeo"]
+
+  let typeDefs = `
+    type MarkdownRemarkFrontmatterSectionsComponents implements Node {
+      body: String
+    }
+
+    interface ModelFrontmatter {
+      id: ID!
+    }
+
+    type MarkdownRemarkFields implements Node {
+      frontmatter: ModelFrontmatter
+    }
+
+    type SeoMeta implements Node {
+      id: ID!
+    }
+  `
+
+  for (let model of models) {
+    typeDefs += `
+      type ${model} implements Node & ModelFrontmatter {
+        id: ID!
+        seo: SeoMeta
+      }
+    `
+  }
+
+  createTypes(typeDefs)
+}
+
+exports.onCreateNode = ({ node, actions, createNodeId, createContentDigest }, options) => {
   // Only process nodes that were created by gatsby-transformer-remark.
   if (lodash.get(node, "internal.type") !== "MarkdownRemark") return
 
@@ -24,11 +59,28 @@ exports.onCreateNode = ({ node, actions, createNodeId, getNode, createContentDig
   // comprehensive object of options.
   const args = getOptions(options)
 
+  const model = lodash.get(node, `frontmatter.${args.modelField}`)
+
   // Reference we use to know whether or not to create a child SEO node.
   let seoData
 
+  // Set the initial state of the frontmatter to be processed as the slug and
+  // slugPath, along with the frontmatter from the MarkdownRemark node.
+  let frontmatter = {
+    // slug is the filename without the extension.
+    slug: path.basename(node.fileAbsolutePath, path.extname(node.fileAbsolutePath)),
+    // slugPath is the path to the file without the extension and the grouping
+    // content directory.
+    slugPath: getPermalink({
+      absoluteFilePath: node.fileAbsolutePath,
+      contentSrc: args.contentSrc
+    }),
+    // All non-empty properties on the MarkdownRemark node.
+    ...lodash.omitBy(node.frontmatter, lodash.isEmpty)
+  }
+
   // Loop through each key-value pair in the frontmatter.
-  deepForEach(node.frontmatter, (value, key, subject, keyPath) => {
+  deepForEach(frontmatter, (value, key, subject, keyPath) => {
     // Get type of the node. Most will be "default" and are simply passed
     // through to the new node. Others get processed more specifically to their
     // type.
@@ -44,7 +96,7 @@ exports.onCreateNode = ({ node, actions, createNodeId, getNode, createContentDig
       case "md": {
         const newKeyPath = lodash.trimEnd(keyPath, args.markdownSuffix)
         const newValue = processMarkdown(value)
-        if (newValue) lodash.set(node, `frontmatter.${newKeyPath}`, newValue)
+        if (newValue) lodash.set(frontmatter, newKeyPath, newValue)
         break
       }
       // Image keys are converted to a relative path from the markdown file to
@@ -56,35 +108,63 @@ exports.onCreateNode = ({ node, actions, createNodeId, getNode, createContentDig
           imageSrcDir: args.imageSrc,
           value: value
         })
-        if (newValue) lodash.set(node, `frontmatter.${newKeyPath}`, newValue)
+        if (newValue) lodash.set(frontmatter, newKeyPath, newValue)
         break
       }
     }
     // If the key has a type (some keys are ignored), then we pass it through to
     // the new node.
-    if (keyType) lodash.set(node, `frontmatter.${keyPath}`, value)
+    if (keyType) lodash.set(frontmatter, keyPath, value)
   })
 
-  // Process an SEO node if the new node has SEO data attached to it.
-  if (seoData) {
-    const seoNode = {
-      id: createNodeId(`${node.id} - SEO`),
-      children: [],
-      // The parent is the new node we just created.
-      parent: node.id,
-      internal: {
-        contentDigest: createContentDigest(seoData),
-        type: `SeoMeta`
-      },
-      // SEO data is nested under a "data" object to avoid naming conflicts.
-      data: seoData
-    }
-
-    // Create SEO node and also create the parent-child relationship between the
-    // new node and the SEO node.
-    actions.createNode(seoNode)
-    actions.createParentChildLink({ parent: node, child: seoNode })
+  // Initialize a new node as a child of the MarkdownRemark node.
+  let newNode = {
+    id: createNodeId(`${node.id} - ${model}`),
+    children: [],
+    parent: node.id,
+    internal: {
+      contentDigest: createContentDigest(node.internal.content),
+      type: model
+    },
+    // Store the processed frontmatter on the new node.
+    ...frontmatter
   }
 
-  return node
+  // Process an SEO node if the new node has SEO data attached to it.
+  const seoNode = seoData
+    ? {
+        id: createNodeId(`${newNode.id} - SEO`),
+        children: [],
+        parent: newNode.id,
+        internal: {
+          contentDigest: createContentDigest(seoData),
+          type: `SeoMeta`
+        },
+        ...seoData
+      }
+    : null
+
+  // Create the SEO node, then set the new node's frontmatter to the new SEO node.
+  if (seoNode) {
+    actions.createNode(seoNode)
+    lodash.set(newNode, "seo", seoNode)
+  }
+
+  // Create the new node and build a relationship to the parent, so we can use
+  // childMarkdownRemark to get to html and other useful attributes.
+  actions.createNode(newNode)
+  actions.createParentChildLink({ parent: node, child: newNode })
+  // Create the parent-child relationship between the new node and the SEO node.
+  if (seoNode) actions.createParentChildLink({ parent: node, child: seoNode })
+
+  // Add the transformed frontmatter as a field on the MarkdownRemark node,
+  // which will make it available at node.fields.frontmatter.
+  actions.createNodeField({
+    node,
+    name: "frontmatter",
+    value: newNode
+  })
+
+  // Return the newly created node.
+  return newNode
 }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -5,8 +5,16 @@ const path = require("path")
 const getKeyType = require("./utils/get-key-type")
 const getOptions = require("./utils/get-options")
 const getPermalink = require("./utils/get-permalink")
-const processMarkdown = require("./utils/process-markdown")
 const processImage = require("./utils/process-image")
+const processMarkdown = require("./utils/process-markdown")
+
+// TODO: Copy relevant frontmatter into top-level key
+// TODO: Add slug fields
+// TODO: Explicitly set type from schema config
+// TODO: Use schema for processing and remove suffix
+// TODO: Update options
+// TODO: Fix tests
+// TODO: Update documentation
 
 exports.onCreateNode = ({ node, actions, createNodeId, getNode, createContentDigest }, options) => {
   // Only process nodes that were created by gatsby-transformer-remark.
@@ -16,56 +24,13 @@ exports.onCreateNode = ({ node, actions, createNodeId, getNode, createContentDig
   // comprehensive object of options.
   const args = getOptions(options)
 
-  // The name of the model, which is the basis for creating the query. This is
-  // how queries are grouped together.
-  const contentType = lodash.get(node, `frontmatter.${args.modelField}`)
-  // Stop processing if the content type is not a string of some length.
-  if (!lodash.isString(contentType) || lodash.isEmpty(contentType)) return
-
-  // Reference to the parent of the MarkdownRemark node, which should be a file.
-  const fileNode = getNode(node.parent)
-  if (lodash.get(fileNode, "internal.type") !== "File") return
-
-  // Initialize a new node object.
-  const newNode = {
-    // Gatsby helps us create a unique ID for this node.
-    id: createNodeId(`${node.id} - ${contentType}`),
-    // Children has to be an empty array for new objects.
-    children: [],
-    // The parent is the node that was just created, the MarkdownRemark node.
-    parent: node.id,
-    // We use a combination of the MarkdownRemark node, and its parent, the File
-    // node, to build out internal properties.
-    internal: {
-      content: node.internal.content,
-      contentDigest: createContentDigest(node.internal.content),
-      mediaType: fileNode.internal.mediaType,
-      description: fileNode.internal.description,
-      // The type is the name of the model, appended to MarkdownRemark, to show
-      // that this is an extension of MarkdownRemark.
-      type: `MarkdownRemark${contentType}`
-    },
-    // slug is the filename without the extension.
-    slug: path.basename(node.fileAbsolutePath, path.extname(node.fileAbsolutePath)),
-    // slugPath is the path to the file without the extension and the grouping
-    // content directory.
-    slugPath: getPermalink({
-      absoluteFilePath: node.fileAbsolutePath,
-      contentSrc: args.contentSrc
-    }),
-    // html persists from the MarkdownRemark node.
-    html: node.html,
-    // Create an empty object for frontmatter, which is processed below.
-    frontmatter: {}
-  }
-
   // Reference we use to know whether or not to create a child SEO node.
   let seoData
 
   // Loop through each key-value pair in the frontmatter.
-  deepForEach(node.frontmatter, (value, key, _, keyPath) => {
+  deepForEach(node.frontmatter, (value, key, subject, keyPath) => {
     // Get type of the node. Most will be "default" and are simply passed
-    // through to the new node. Others get processed more specifical to their
+    // through to the new node. Others get processed more specifically to their
     // type.
     const keyType = getKeyType({ keyPath: keyPath, options: args, value: value })
     switch (keyType) {
@@ -79,7 +44,7 @@ exports.onCreateNode = ({ node, actions, createNodeId, getNode, createContentDig
       case "md": {
         const newKeyPath = lodash.trimEnd(keyPath, args.markdownSuffix)
         const newValue = processMarkdown(value)
-        if (newValue) lodash.set(newNode, `frontmatter.${newKeyPath}`, newValue)
+        if (newValue) lodash.set(node, `frontmatter.${newKeyPath}`, newValue)
         break
       }
       // Image keys are converted to a relative path from the markdown file to
@@ -91,19 +56,14 @@ exports.onCreateNode = ({ node, actions, createNodeId, getNode, createContentDig
           imageSrcDir: args.imageSrc,
           value: value
         })
-        if (newValue) lodash.set(newNode, `frontmatter.${newKeyPath}`, newValue)
+        if (newValue) lodash.set(node, `frontmatter.${newKeyPath}`, newValue)
         break
       }
     }
     // If the key has a type (some keys are ignored), then we pass it through to
     // the new node.
-    if (keyType) lodash.set(newNode, `frontmatter.${keyPath}`, value)
+    if (keyType) lodash.set(node, `frontmatter.${keyPath}`, value)
   })
-
-  // Create the new node.
-  actions.createNode(newNode)
-  // Set the parent of the new node to the MarkdownRemark node.
-  actions.createParentChildLink({ parent: node, child: newNode })
 
   // Process an SEO node if the new node has SEO data attached to it.
   if (seoData) {
@@ -111,7 +71,7 @@ exports.onCreateNode = ({ node, actions, createNodeId, getNode, createContentDig
       id: createNodeId(`${node.id} - SEO`),
       children: [],
       // The parent is the new node we just created.
-      parent: newNode.id,
+      parent: node.id,
       internal: {
         contentDigest: createContentDigest(seoData),
         type: `SeoMeta`
@@ -123,8 +83,8 @@ exports.onCreateNode = ({ node, actions, createNodeId, getNode, createContentDig
     // Create SEO node and also create the parent-child relationship between the
     // new node and the SEO node.
     actions.createNode(seoNode)
-    actions.createParentChildLink({ parent: newNode, child: seoNode })
+    actions.createParentChildLink({ parent: node, child: seoNode })
   }
 
-  return newNode
+  return node
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-remark-ample",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "dependencies": {
     "deep-for-each": "^3.0.0",
     "lodash": "^4.17.15",

--- a/package.json
+++ b/package.json
@@ -12,5 +12,6 @@
   },
   "scripts": {
     "test": "jest ./utils"
-  }
+  },
+  "license": "MIT"
 }

--- a/utils/get-key-type.js
+++ b/utils/get-key-type.js
@@ -4,6 +4,8 @@ const path = require("path")
 module.exports = ({ keyPath, options, value }) => {
   // SEO objects are those that match the SEO field key.
   if (keyPath === options.seoField) return "seo"
+  // Ignore type inside the SEO object.
+  if (keyPath.split(".")[0] === options.seoField) return undefined
   // Markdown fields are those whose key ends with the markdown suffix.
   if (lodash.endsWith(keyPath, options.markdownSuffix)) return "md"
   // Keys that end with the image suffix, whose value starts with the path

--- a/utils/get-key-type.js
+++ b/utils/get-key-type.js
@@ -4,8 +4,6 @@ const path = require("path")
 module.exports = ({ keyPath, options, value }) => {
   // SEO objects are those that match the SEO field key.
   if (keyPath === options.seoField) return "seo"
-  // Ignore type inside the SEO object.
-  if (keyPath.split(".")[0] === options.seoField) return undefined
   // Markdown fields are those whose key ends with the markdown suffix.
   if (lodash.endsWith(keyPath, options.markdownSuffix)) return "md"
   // Keys that end with the image suffix, whose value starts with the path

--- a/utils/get-key-type.test.js
+++ b/utils/get-key-type.test.js
@@ -12,6 +12,10 @@ describe("getKeyType", () => {
     const result = getKeyType({ keyPath: "seo", value: {}, options: options })
     expect(result).toEqual("seo")
   })
+  it('does not return "seo" for matching nested "seo" keys', () => {
+    const result = getKeyType({ keyPath: "hello.seo", value: {}, options: options })
+    expect(result).toEqual("default")
+  })
   it("returns undefined for nested seo keys", () => {
     const result = getKeyType({ keyPath: "seo.title", value: "world", options: options })
     expect(result).toEqual(undefined)

--- a/utils/get-options.js
+++ b/utils/get-options.js
@@ -9,6 +9,7 @@ module.exports = (overrides = {}) => {
     imageSuffix: "_src",
     markdownSuffix: "_md",
     modelField: "model",
+    models: [],
     seoField: "seo"
   }
 

--- a/utils/get-options.test.js
+++ b/utils/get-options.test.js
@@ -10,6 +10,7 @@ describe("getOptions", () => {
       imageSrc: path.join(__dirname, "../../../static"),
       markdownSuffix: "_md",
       modelField: "model",
+      models: [],
       seoField: "seo"
     })
   })
@@ -20,6 +21,7 @@ describe("getOptions", () => {
     expect(getOptions({ imageSrc: "./uploads" }).imageSrc).toEqual("./uploads")
     expect(getOptions({ markdownSuffix: "__m__" }).markdownSuffix).toEqual("__m__")
     expect(getOptions({ modelField: "_tmpl" }).modelField).toEqual("_tmpl")
+    expect(getOptions({ models: ["Page", "Post"] }).models).toEqual(["Page", "Post"])
     expect(getOptions({ seoField: "__s__" }).seoField).toEqual("__s__")
   })
   it("adds a trailing slash to contentSrc", () => {

--- a/utils/process-frontmatter.js
+++ b/utils/process-frontmatter.js
@@ -1,0 +1,49 @@
+const deepForEach = require("deep-for-each")
+const lodash = require("lodash")
+
+const getKeyType = require("./get-key-type")
+const processImage = require("./process-image")
+const processMarkdown = require("./process-markdown")
+
+module.exports = ({ frontmatter = {}, node = {}, options = {} }) => {
+  // An object to reference SEO data. This is pulled out separately because we
+  // don't have all the info we need to create a node at this time.
+  let seoData = undefined
+  // Loop through every property on the frontmatter object.
+  deepForEach(frontmatter, (value, key, subject, keyPath) => {
+    // Get type of the node. Most will be "default" and are left alone. Others
+    // are processed specifically to their type.
+    const keyType = getKeyType({ keyPath: keyPath, options: options, value: value })
+    // Perform an action, based on the type.
+    switch (keyType) {
+      // SEO keys replace the SEO object with a new node.
+      case "seo":
+        seoData = value
+        delete frontmatter[options.seoField]
+        break
+      // Markdown keys are converted to HTML and stored as a new key without the
+      // suffix.
+      case "md": {
+        const newKeyPath = lodash.trimEnd(keyPath, options.markdownSuffix)
+        const newValue = processMarkdown(value)
+        if (newValue) lodash.set(frontmatter, newKeyPath, newValue)
+        break
+      }
+      // Image keys are converted to a relative path from the markdown file to
+      // the image, and stored as a new key without the suffix.
+      case "img": {
+        const newKeyPath = lodash.trimEnd(keyPath, options.imageSuffix)
+        const newValue = processImage({
+          absoluteFilePath: node.fileAbsolutePath,
+          imageSrcDir: options.imageSrc,
+          value: value
+        })
+        if (newValue) lodash.set(frontmatter, newKeyPath, newValue)
+        break
+      }
+    }
+  })
+
+  // Return the transformed frontmatter, along with the seoData.
+  return { frontmatter: frontmatter, seoData: seoData }
+}

--- a/utils/process-frontmatter.test.js
+++ b/utils/process-frontmatter.test.js
@@ -1,0 +1,56 @@
+const processFrontmatter = require("./process-frontmatter")
+const getOptions = require("./get-options")
+const path = require("path")
+
+const options = getOptions()
+
+const absoluteFilePath = path.join(__dirname, "./__fixtures__/test-01/test-02.md")
+const imageSrcDir = path.join(__dirname, "./__fixtures__")
+
+describe("processFrontmatter", () => {
+  it("passes non-processable properties through", () => {
+    const fm = { hello: "world" }
+    const result = processFrontmatter({ frontmatter: fm, options: options })
+    expect(result).toEqual({ frontmatter: fm })
+  })
+  it("extracts seoData and deletes the key from frontmatter", () => {
+    const fm = { seo: { title: "Hello World" }, title: "Hello World" }
+    const result = processFrontmatter({ frontmatter: fm, options: options })
+    expect(result).toEqual({
+      frontmatter: { title: "Hello World" },
+      seoData: { title: "Hello World" }
+    })
+  })
+  it("processes markdown fields", () => {
+    const fm = { test_md: "Hello world" }
+    const result = processFrontmatter({ frontmatter: fm, options: options })
+    expect(result).toEqual({
+      frontmatter: { test_md: "Hello world", test: "<p>Hello world</p>\n" }
+    })
+  })
+  it("processes nested markdown fields", () => {
+    const fm = { a: { b: [{ test_md: "Hello world" }] } }
+    const result = processFrontmatter({ frontmatter: fm, options: options })
+    expect(result).toEqual({
+      frontmatter: { a: { b: [{ test_md: "Hello world", test: "<p>Hello world</p>\n" }] } }
+    })
+  })
+  it("processes image fields", () => {
+    const options = getOptions({ imageSrc: imageSrcDir })
+    const fm = { test_src: "/images/pto.png" }
+    const node = { fileAbsolutePath: absoluteFilePath }
+    const result = processFrontmatter({ frontmatter: fm, options: options, node: node })
+    expect(result).toEqual({
+      frontmatter: { test_src: "/images/pto.png", test: "../images/pto.png" }
+    })
+  })
+  it("processes nested image fields", () => {
+    const options = getOptions({ imageSrc: imageSrcDir })
+    const fm = { a: { b: [{ test_src: "/images/pto.png" }] } }
+    const node = { fileAbsolutePath: absoluteFilePath }
+    const result = processFrontmatter({ frontmatter: fm, options: options, node: node })
+    expect(result).toEqual({
+      frontmatter: { a: { b: [{ test_src: "/images/pto.png", test: "../images/pto.png" }] } }
+    })
+  })
+})


### PR DESCRIPTION
Bumped to v0.2.0 because I made a few big changes here:

- Explicit type definitions for a new option, `models`, that can be passed in.
- Processed frontmatter does not get stored back on the MarkdownRemark node, but uses Gatsby's Node APIs to store it on `fields.processed_frontmatter` **as the appropriate type**, if the models option is declared.
- It still creates a child node.
- Avoids creating duplicate nodes by ignoring that the structured node is a descendant of a File node.
- Solidified process for making sure we're processing SEO data, as well, prior to creating the node.

See README updates for more info.