### PR TITLE
v0.3.0 - Add `filePath` to child nodes

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -3,6 +3,7 @@ const path = require("path")
 
 const getOptions = require("./utils/get-options")
 const getPermalink = require("./utils/get-permalink")
+const getFilePath = require("./utils/get-file-path")
 const processFrontmatter = require("./utils/process-frontmatter")
 
 exports.createSchemaCustomization = ({ actions }, options) => {
@@ -16,6 +17,7 @@ exports.createSchemaCustomization = ({ actions }, options) => {
       id: ID!
       slug: String
       slugPath: String
+      filePath: String
     }
 
     type MarkdownRemarkFields implements Node {
@@ -58,8 +60,9 @@ exports.onCreateNode = ({ node, actions, createNodeId, createContentDigest }, op
   // the type is unknown.
   if (!model) return
 
-  // Set the initial state of the frontmatter to be processed as the slug and
-  // slugPath, along with the frontmatter from the MarkdownRemark node.
+  // Set the initial state of the frontmatter to be processed as the slug,
+  // slugPath, and filePath, along with the frontmatter from the MarkdownRemark
+  // node.
   const initFrontmatter = {
     // slug is the filename without the extension.
     slug: path.basename(node.fileAbsolutePath, path.extname(node.fileAbsolutePath)),
@@ -68,6 +71,11 @@ exports.onCreateNode = ({ node, actions, createNodeId, createContentDigest }, op
     slugPath: getPermalink({
       absoluteFilePath: node.fileAbsolutePath,
       contentSrc: args.contentSrc
+    }),
+    // filePath is the path to the file, relative to the project root directory
+    filePath: getFilePath({
+      absoluteFilePath: node.fileAbsolutePath,
+      projectRoot: args.projectRoot
     }),
     // Bring in frontmatter from MarkdownRemark node.
     ...node.frontmatter

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -54,6 +54,10 @@ exports.onCreateNode = ({ node, actions, createNodeId, createContentDigest }, op
   // translate to the new frontmatter field, too.
   const model = lodash.get(node, `frontmatter.${args.modelField}`)
 
+  // If the model was not specified, then don't try to create the node because
+  // the type is unknown.
+  if (!model) return
+
   // Set the initial state of the frontmatter to be processed as the slug and
   // slugPath, along with the frontmatter from the MarkdownRemark node.
   const initFrontmatter = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-remark-ample",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "dependencies": {
     "deep-for-each": "^3.0.0",
     "lodash": "^4.17.15",

--- a/utils/get-file-path.js
+++ b/utils/get-file-path.js
@@ -1,0 +1,11 @@
+const lodash = require("lodash")
+const path = require("path")
+
+module.exports = ({ absoluteFilePath, projectRoot }) => {
+  // Remove everything before the content directory.
+  let filePath = absoluteFilePath.split(projectRoot).pop()
+  // Split the remaining path into its individual parts.
+  filePath = lodash.compact(filePath.split(path.sep))
+  // Convert the path back into a string, and remove the extension.
+  return filePath.join(path.sep)
+}

--- a/utils/get-file-path.test.js
+++ b/utils/get-file-path.test.js
@@ -1,0 +1,19 @@
+const getFilePath = require("./get-file-path")
+const path = require("path")
+
+const projectRoot = path.join(__dirname, "..")
+const absoluteFilePath = path.join(projectRoot, "__fixtures__/test-01/test-02.md")
+
+describe("getFilePath", () => {
+  it("returns the relative path from the project root directory", () => {
+    const result = getFilePath({ absoluteFilePath: absoluteFilePath, projectRoot: projectRoot })
+    expect(result).toEqual("__fixtures__/test-01/test-02.md")
+  })
+  it("provides the same result when the project root ends with a slash", () => {
+    const result = getFilePath({
+      absoluteFilePath: absoluteFilePath,
+      projectRoot: projectRoot + path.sep
+    })
+    expect(result).toEqual("__fixtures__/test-01/test-02.md")
+  })
+})

--- a/utils/get-options.js
+++ b/utils/get-options.js
@@ -10,6 +10,7 @@ module.exports = (overrides = {}) => {
     markdownSuffix: "_md",
     modelField: "model",
     models: [],
+    projectRoot: path.join(__dirname, "../../../"),
     seoField: "seo"
   }
 

--- a/utils/get-options.test.js
+++ b/utils/get-options.test.js
@@ -11,6 +11,7 @@ describe("getOptions", () => {
       markdownSuffix: "_md",
       modelField: "model",
       models: [],
+      projectRoot: path.join(__dirname, "../../../"),
       seoField: "seo"
     })
   })

--- a/utils/get-permalink.test.js
+++ b/utils/get-permalink.test.js
@@ -9,6 +9,10 @@ describe("getPermalink", () => {
     const result = getPermalink({ absoluteFilePath: absoluteFilePath, contentSrc: contentSrc })
     expect(result).toEqual("test-01/test-02")
   })
+  it("returns the same result when using a relative path as the content source", () => {
+    const result = getPermalink({ absoluteFilePath: absoluteFilePath, contentSrc: "utils" })
+    expect(result).toEqual("test-01/test-02")
+  })
   it("provides the same result when the contentSrc ends with a slash", () => {
     const result = getPermalink({
       absoluteFilePath: absoluteFilePath,


### PR DESCRIPTION
- Adds `filePath` to child node. (See updates in README for functionality.)
- Fixes bug so we don't try to create child nodes when we couldn't find the model